### PR TITLE
Completely stop when an errors occurred

### DIFF
--- a/src/Lib/MonitorHandler.php
+++ b/src/Lib/MonitorHandler.php
@@ -105,7 +105,7 @@ class MonitorHandler
             foreach ($errors as $error) {
                 echo $error . '<br><br>';
             }
-            return;
+            die;
         }
         $this->_config['onSuccess']();
     }


### PR DESCRIPTION
This change is to prevent the following warning:
`Warning (512): Unable to emit headers. Headers sent in file=/Users/jneugber/Sites/magicplan_cloud/vendor/scherersoftware/cake-monitor/src/Lib/MonitorHandler.php line=104 [CORE/src/Http/ResponseEmitter.php, line 48]`
