### PR TITLE
Send extra data with every captureMessage to Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ The `CakeMonitor` configuration section in your `app.php` must contain a `Sentry
 				$data['user']['id'] = '*****';
 			}
 		},
+		'extraDataCallback' => function() { # Extra data to send with every Sentry call. Works with SentryHandler::captureMessage() only!
+            if (!empty($_SESSION['Test'])) {
+                return $_SESSION['Test'];
+            }
+        }
 	]
 
 In your `bootstrap.php` you have to tell CakePHP which ErrorHandler to use. Please find the following section:

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ The `CakeMonitor` configuration section in your `app.php` must contain a `Sentry
 			}
 		},
 		'extraDataCallback' => function() { # Extra data to send with every Sentry call. Works with SentryHandler::captureMessage() only!
-            if (!empty($_SESSION['Test'])) {
-                return $_SESSION['Test'];
-            }
-        }
+            	if (!empty($_SESSION['Test'])) {
+                		return $_SESSION['Test'];
+            	}
+        	}
 	]
 
 In your `bootstrap.php` you have to tell CakePHP which ErrorHandler to use. Please find the following section:

--- a/config/monitor.default.php
+++ b/config/monitor.default.php
@@ -13,7 +13,8 @@ return [
             'enabled' => false,
             'dsn' => null,
             'sanitizeFields' => [],
-            'sanitizeExtraCallback' => null
+            'sanitizeExtraCallback' => null,
+            'extraDataCallback' => null
         ]
     ]
 ];

--- a/src/Error/SentryHandler.php
+++ b/src/Error/SentryHandler.php
@@ -68,6 +68,10 @@ class SentryHandler
             return false;
         }
 
+        if (is_callable(Configure::read('CakeMonitor.Sentry.extraDataCallback'))) {
+            $data['extra']['extraDataCallback'] = call_user_func_array(Configure::read('CakeMonitor.Sentry.extraDataCallback'), []);
+        }
+
         return $this->_ravenClient->captureMessage($message, $params, $data, $stack, $vars);
     }
 }

--- a/src/Error/SentryHandler.php
+++ b/src/Error/SentryHandler.php
@@ -69,7 +69,7 @@ class SentryHandler
         }
 
         if (is_callable(Configure::read('CakeMonitor.Sentry.extraDataCallback'))) {
-            $data['extra']['extraDataCallback'] = call_user_func_array(Configure::read('CakeMonitor.Sentry.extraDataCallback'), []);
+            $data['extra']['extraDataCallback'] = call_user_func(Configure::read('CakeMonitor.Sentry.extraDataCallback'));
         }
 
         return $this->_ravenClient->captureMessage($message, $params, $data, $stack, $vars);


### PR DESCRIPTION
To generally add and send data (e.g. session data for better debugging) with every captureMessage() call to Sentry, I've implemented a new callback "extraDataCallback".